### PR TITLE
Clean up the misuse of gitignore

### DIFF
--- a/.config/.gitignore
+++ b/.config/.gitignore
@@ -1,2 +1,6 @@
-!fish/
-!venv-update/
+configstore/
+fzf/
+virtualenv/
+http-prompt/
+htop/
+git/

--- a/.config/fish/.gitignore
+++ b/.config/fish/.gitignore
@@ -1,1 +1,4 @@
 config_local.fish
+plugins/
+fishd.*
+functions/fish_prompt.[0-9]*.copy

--- a/.config/pudb/.gitignore
+++ b/.config/pudb/.gitignore
@@ -1,0 +1,2 @@
+saved-breakpoints-*
+shell-history

--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,9 @@
 # Ignore most things.
 /*
-!.gitignore
 
 # But there are some things I'd like to keep track of.
 # These directories all have their own .gitignore file.
 !README
 !bin
-!docs
-!trees
 !.vim
-!.ssh
-!.bash_completion.d
-!.subversion
-!.bashrc
-!.bash_profile
-!.bash_function
-!.irssi
-!.vimrc
-!.inputrc
-!.vimperatorrc
-!.gvimrc
-!.pythonrc.py
-!.xmodmaprc
-!.xpdfrc
-!.usercontent.css
-!.gitconfig
 !.config

--- a/.vim/.gitignore
+++ b/.vim/.gitignore
@@ -1,0 +1,3 @@
+autoload/
+bundle/
+.netrwhist


### PR DESCRIPTION
The operating model is now to whitelist directories and files at the
root level. Every subsequent level will then use gitignore as a
blacklist, which is is a common use case. This will prevent cases where
we have files that are ignored when we actually want to add it to repo.

Fixes #1 