### PR TITLE
Move local virtualenv to XDG local directory

### DIFF
--- a/.config/fish/conf.d/001_virtualenv.fish
+++ b/.config/fish/conf.d/001_virtualenv.fish
@@ -2,7 +2,7 @@
 
 if status --is-login; and status --is-interactive; and type -q virtualenv;
 
-    set venv "$XDG_CONFIG_HOME/virtualenv"
+    set venv "$XDG_DATA_HOME/virtualenv"
     set venv_update "$XDG_CONFIG_HOME/venv-update/venv-update"
     set requirements "$XDG_CONFIG_HOME/venv-update/requirements.txt"
     set logfile "$XDG_CACHE_HOME/venv-update/log"


### PR DESCRIPTION
XDG local directory is the correct location for virtualenv as it can be
easily recreated from configs but is still required for a proper
development setup.

Fixes #7 