### PR TITLE
Grant permissions for superpowers and compound engineering skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,10 +3,7 @@
     "allow": [
       "Read(~/.claude/plugins/cache/**)",
       "Bash(python3 ~/.claude/plugins/cache/compound-engineering-plugin/**)",
-      "Read(~/.claude/plans/**)",
-      "Write(~/.claude/plans/**)",
-      "Edit(~/.claude/plans/**)",
-      "Write(docs/superpowers/**)",
+"Write(docs/superpowers/**)",
       "Edit(docs/superpowers/**)",
       "Bash(mkdir -p docs/superpowers/**)",
       "Write(docs/plans/*.md)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,22 +3,25 @@
     "allow": [
       "Read(~/.claude/plugins/cache/**)",
       "Bash(python3 ~/.claude/plugins/cache/compound-engineering-plugin/**)",
-"Write(docs/superpowers/**)",
+      "Read(docs/superpowers/**)",
+      "Write(docs/superpowers/**)",
       "Edit(docs/superpowers/**)",
-      "Bash(mkdir -p docs/superpowers/**)",
+      "Read(docs/plans/*.md)",
       "Write(docs/plans/*.md)",
       "Edit(docs/plans/*.md)",
-      "Bash(mkdir -p docs/plans)",
+      "Read(docs/brainstorms/*.md)",
       "Write(docs/brainstorms/*.md)",
       "Edit(docs/brainstorms/*.md)",
-      "Bash(mkdir -p docs/brainstorms)",
+      "Read(docs/solutions/**/*.md)",
       "Write(docs/solutions/**/*.md)",
       "Edit(docs/solutions/**/*.md)",
-      "Bash(mkdir -p docs/solutions/**)"
+      "Bash(mkdir -p docs/**)"
     ],
     "ask": [
       "Edit(AGENTS.md)",
-      "Edit(CLAUDE.md)"
+      "Write(AGENTS.md)",
+      "Edit(CLAUDE.md)",
+      "Write(CLAUDE.md)"
     ]
   },
   "enabledPlugins": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,35 @@
 {
   "permissions": {
     "allow": [
-      "Read(~/.claude/plugins/cache/compound-engineering-plugin/*)",
-      "Edit(~/.agents/docs/solutions/*)",
-      "Write(~/.agents/docs/solutions/*)",
-      "Bash(python3 ~/.claude/plugins/cache/compound-engineering-plugin/*)"
+      "Read(~/.claude/plugins/cache/compound-engineering-plugin/**)",
+      "Read(~/.claude/plugins/cache/**)",
+      "Edit(~/.agents/docs/solutions/**)",
+      "Write(~/.agents/docs/solutions/**)",
+      "Read(~/.agents/docs/solutions/**)",
+      "Read(.agents/docs/solutions/**)",
+      "Edit(.agents/docs/solutions/**)",
+      "Write(.agents/docs/solutions/**)",
+      "Bash(mkdir -p ~/.agents/docs/solutions/**)",
+      "Bash(python3 ~/.claude/plugins/cache/compound-engineering-plugin/**)",
+      "Read(~/.claude/plans/**)",
+      "Write(~/.claude/plans/**)",
+      "Edit(~/.claude/plans/**)",
+      "Write(docs/superpowers/**)",
+      "Edit(docs/superpowers/**)",
+      "Bash(mkdir -p docs/superpowers/**)",
+      "Write(docs/plans/*.md)",
+      "Edit(docs/plans/*.md)",
+      "Bash(mkdir -p docs/plans)",
+      "Write(docs/brainstorms/*.md)",
+      "Edit(docs/brainstorms/*.md)",
+      "Bash(mkdir -p docs/brainstorms)",
+      "Write(docs/solutions/**/*.md)",
+      "Edit(docs/solutions/**/*.md)",
+      "Bash(mkdir -p docs/solutions/**)"
+    ],
+    "ask": [
+      "Edit(AGENTS.md)",
+      "Edit(CLAUDE.md)"
     ]
   },
   "enabledPlugins": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "permissions": {
     "allow": [
-      "Read(~/.claude/plugins/cache/**)",
+      "Read(~/.claude/plugins/cache/compound-engineering-plugin/**)",
       "Bash(python3 ~/.claude/plugins/cache/compound-engineering-plugin/**)",
       "Read(docs/superpowers/**)",
       "Write(docs/superpowers/**)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,10 +16,6 @@
       "Write(docs/solutions/**/*.md)",
       "Edit(docs/solutions/**/*.md)",
       "Bash(mkdir -p docs/**)"
-    ],
-    "ask": [
-      "Edit(CLAUDE.md)",
-      "Write(CLAUDE.md)"
     ]
   },
   "enabledPlugins": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,7 @@
 {
   "permissions": {
     "allow": [
-      "Read(~/.claude/plugins/cache/compound-engineering-plugin/**)",
       "Read(~/.claude/plugins/cache/**)",
-      "Edit(~/.agents/docs/solutions/**)",
-      "Write(~/.agents/docs/solutions/**)",
-      "Read(~/.agents/docs/solutions/**)",
-      "Read(.agents/docs/solutions/**)",
-      "Edit(.agents/docs/solutions/**)",
-      "Write(.agents/docs/solutions/**)",
-      "Bash(mkdir -p ~/.agents/docs/solutions/**)",
       "Bash(python3 ~/.claude/plugins/cache/compound-engineering-plugin/**)",
       "Read(~/.claude/plans/**)",
       "Write(~/.claude/plans/**)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,8 +18,6 @@
       "Bash(mkdir -p docs/**)"
     ],
     "ask": [
-      "Edit(AGENTS.md)",
-      "Write(AGENTS.md)",
       "Edit(CLAUDE.md)",
       "Write(CLAUDE.md)"
     ]


### PR DESCRIPTION
Allow skills to write planning artifacts and solution docs without
permission prompts across any project. Gate AGENTS.md/CLAUDE.md edits
via ask permissions so they prompt even in bypass mode.

- Fix single-level glob (* → **) for ~/.agents/docs/solutions/
- Add both tilde and relative forms of .agents/ paths
- Add docs/superpowers/**, docs/plans/, docs/brainstorms/, docs/solutions/**
- Add ~/.claude/plans/** for plan mode files
- Add ~/.claude/plugins/cache/** for plugin scripts
- Add permissions.ask for AGENTS.md and CLAUDE.md

https://claude.ai/code/session_01NyWN1C8s7i2koX1hdS9WEs