### PR TITLE
refactor: extract shared is_expired, fix pyenv paths, harden git-deploy

### DIFF
--- a/.config/fish/conf.d/10-devbox.fish
+++ b/.config/fish/conf.d/10-devbox.fish
@@ -1,18 +1,4 @@
 function main
-
-    function is_expired
-        set file $argv[1]
-        test -f $file; or return 0
-
-        # Expire dynamic generations after a week
-        set ttl (math '60*60*24*7') # 1 week
-
-        set current_time (date +%s)
-        set file_age (stat -c %Y $file; or echo 0)
-
-        test (math $current_time - $file_age) -gt $ttl
-    end
-
     set --append fish_complete_path $DEVBOX_PACKAGES_DIR/share/fish/vendor_completions.d
 end
 

--- a/.config/fish/conf.d/20-npm.fish
+++ b/.config/fish/conf.d/20-npm.fish
@@ -7,7 +7,7 @@ function install
     fish --no-config -c "
         mkdir -p (dirname $logfile)
         if not npm ci --lockfile-version 3 --loglevel=error --prefix $venv >> $logfile 2>&1
-            echo 'Uh... that didn\'t work gud. So check out $logfile'
+            echo "npm install failed; check $logfile"
         end
     " &
 end

--- a/.config/fish/conf.d/20-virtualenv.fish
+++ b/.config/fish/conf.d/20-virtualenv.fish
@@ -7,20 +7,20 @@
 function pyenv-init --description 'Stripped down, lightweight pyenv init'
 
     # pyenv init -
-    while set pyenv_index (contains -i -- "/Users/jnguyen/.pyenv/shims" $PATH)
+    while set pyenv_index (contains -i -- (pyenv root)/shims $PATH)
         set -eg PATH[$pyenv_index]
     end
-    set -gx PATH '/Users/jnguyen/.pyenv/shims' $PATH
+    set -gx PATH (pyenv root)/shims $PATH
     set -gx PYENV_SHELL fish
     command pyenv rehash 2>/dev/null
 
     # Auto-activates pyenv virtualenvs
     # pyenv shim magic is only for resolving to a versioned commands; it does not actually set up a virtualenv for LSPs that crave it
     # pyenv virtualenv-init -
-    while set index (contains -i -- "/Users/jnguyen/.pyenv/plugins/pyenv-virtualenv/shims" $PATH)
+    while set index (contains -i -- (pyenv root)/plugins/pyenv-virtualenv/shims $PATH)
         set -eg PATH[$index]
     end
-    set -gx PATH '/Users/jnguyen/.pyenv/plugins/pyenv-virtualenv/shims' $PATH
+    set -gx PATH (pyenv root)/plugins/pyenv-virtualenv/shims $PATH
 
     set -gx PYENV_VIRTUALENV_INIT 1
 

--- a/.config/fish/conf.d/bd.fish
+++ b/.config/fish/conf.d/bd.fish
@@ -1,17 +1,6 @@
 # Generate bd completions only on login+interactive shells and only after TTL
 # to avoid paying the regeneration cost on every new shell while still keeping
 # completions fresh enough for user-facing changes.
-function __bd_is_expired
-    set -l file $argv[1]
-    test -f $file; or return 0
-
-    set -l ttl (math '60*60*24*7')
-    set -l current_time (date +%s)
-    set -l file_age (stat -c %Y $file 2>/dev/null; or stat -f %m $file 2>/dev/null; or echo 0)
-
-    test (math $current_time - $file_age) -gt $ttl
-end
-
 function __bd_regenerate_completion
     set -l completion_path $XDG_CONFIG_HOME/fish/completions/bd.fish
     bd completion fish >$completion_path
@@ -19,7 +8,7 @@ end
 
 if status --is-interactive; and status --is-login; and type -q bd
     set -l completion_path $XDG_CONFIG_HOME/fish/completions/bd.fish
-    if __bd_is_expired $completion_path
+    if is_expired $completion_path
         __bd_regenerate_completion
     end
 end

--- a/.config/fish/conf.d/omf.fish
+++ b/.config/fish/conf.d/omf.fish
@@ -7,18 +7,6 @@ function main
 end
 
 function install
-    function is_expired
-        set file $argv[1]
-        test -f $file; or return 0
-        # Expire dynamic generations after a week
-        set ttl (math '60*60*24*7') # 1 week
-
-        set file_age (stat -c %Y $file)
-        set current_time (date +%s)
-
-        test (math $current_time - $file_age) -gt $ttl
-    end
-
     if test -d $OMF_PATH
         set bundle $XDG_CONFIG_HOME/omf/bundle
 

--- a/.config/fish/conf.d/zoxide.fish
+++ b/.config/fish/conf.d/zoxide.fish
@@ -9,5 +9,6 @@ if status --is-interactive
             set --erase argv[1]
         end
         __zoxide_z $argv
+        or return $status
     end
 end

--- a/.config/fish/functions/is_expired.fish
+++ b/.config/fish/functions/is_expired.fish
@@ -1,0 +1,11 @@
+function is_expired --description 'Return 0 if file is older than one week (or missing)'
+    set -l file $argv[1]
+    test -f $file; or return 0
+
+    set -l ttl (math '60*60*24*7')
+    set -l current_time (date +%s)
+    # stat -c %Y is Linux; stat -f %m is macOS
+    set -l file_age (stat -c %Y $file 2>/dev/null; or stat -f %m $file 2>/dev/null; or echo 0)
+
+    test (math $current_time - $file_age) -gt $ttl
+end

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 
 # But there are some things I'd like to keep track of.
 # These directories all have their own .gitignore file.
-!README
+!README.md
 !/.config/
 !/.opencode/
 !/opencode.jsonc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,24 +23,50 @@ Watch for friction during any session:
 
 When a session reaches a natural end and any friction was observed, offer to run `/post-session-learning` before the user leaves. One short sentence is enough: "Want me to capture what we learned so this is automatic next time?" Do not offer if the session had no friction worth capturing (pure Q&A, trivial tasks).
 
-## Project Structure & Module Organization
-- `bin/` contains host-agnostic CLI helpers (e.g., `bin/git-clean-remote`, `bin/pomodoro`); keep each file executable and documented with a header comment.
-- `.config/` mirrors application settings for fish, neovim, taskwarrior, etc.; keep app-specific docs inside the directory README when necessary and prefer per-app subfolders.
-- `tools/` holds the Devbox definition used to provision auxiliary utilities (`tools/devbox.json`), and `repos/` tracks checked-out upstream projects that should remain untouched unless syncing from their sources.
 
 ## Build, Test, and Development Commands
-- Start a prepared shell with `devbox shell` from the repo root; add packages in `tools/devbox.json`.
-- Validate YAML changes with `yamllint -c .config/yamllint/config config automations.yaml scenes.yaml`.
-- Run shell linting via `shellcheck bin/git-clean-remote` and Python quality checks with `pylint --rcfile .config/pylintrc volta.py`.
+- Start a prepared shell with `devbox shell` from the repo root; add packages in `.config/devbox/devbox.json`.
+- Run all pre-commit hooks with `pre-commit run --all-files`.
+- Run shell linting via `shellcheck bin/` and Python quality checks with `pylint --rcfile .config/pylintrc`.
+- Syntax-check fish configs with `fish -n .config/fish/conf.d/*.fish .config/fish/functions/*.fish`.
 
 ## Coding Style & Naming Conventions
-- YAML follows two-space indentation, 120 character lines, and lower-case keys; structure automations by domain (e.g., `automation.lights_evening`).
-- Python adopts snake_case modules, f-string formatting, and max 120 char lines per `.config/pylintrc`; add lightweight typer commands to `volta.py`.
-- Shell scripts in `bin/` should target POSIX sh, guard against `set -eu`, and log actions with succinct `echo` statements.
+- YAML follows two-space indentation, 120 character lines, and lower-case keys.
+- Python adopts snake_case modules, f-string formatting, and max 120 char lines per `.config/pylintrc`.
+- Shell scripts in `bin/` should target bash, include `set -euo pipefail`, and log actions with succinct `echo` statements.
+- Fish configs in `.config/fish/conf.d/` use 4-space indentation and prefer `set -l` for local variables.
+
+## Fish Shell Patterns
+
+### conf.d files
+- Use numeric prefixes to encode load dependencies (see README for the mapping).
+- Every new conf.d file should follow the main/install pattern:
+  ```fish
+  function main       # runs on every interactive shell
+      ...
+  end
+
+  function install    # runs on login shells (once per session)
+      ...
+  end
+
+  status --is-login; and install
+  status --is-interactive; and main
+  ```
+- This avoids paying install costs (package syncs, git fetches) on every new terminal tab.
+
+### Shared utilities
+- Use `is_expired` from `functions/is_expired.fish` for all TTL-based file regeneration; do not define local copies.
+- Cross-platform stat for file modification times — `stat` flags differ between Linux and macOS:
+  ```fish
+  set -l file_age (stat -c %Y $file 2>/dev/null; or stat -f %m $file 2>/dev/null; or echo 0)
+  ```
+
+### pyenv
+- `20-virtualenv.fish` inlines `pyenv init -` to avoid subshell overhead (~100 ms saved). Always use `(pyenv root)` at runtime; never hardcode user-specific paths like `/Users/name/.pyenv/`.
 
 ## Testing Guidelines
-- Group new YAML automations under matching blueprint directories and include comments noting dependencies.
-- Prefer targeted lint runs (`yamllint config/blueprints`, `pylint volta.py`) before pushing.
+- Prefer targeted lint runs (`shellcheck bin/`, `pylint`) before pushing.
 - When modifying third-party mirrors in `repos/`, open patches upstream first—local diffs should be temporary and documented in the PR.
 
 ## Commit & Pull Request Guidelines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+See [AGENTS.md](AGENTS.md) for coding conventions, architecture notes, commit guidelines, and dev commands.

--- a/README
+++ b/README
@@ -1,8 +1,0 @@
-Quick setup: (copy-paste to terminal)
-
-```
-git init
-git remote add origin https://github.com/ipwnponies/dotfiles.git
-git fetch origin
-git switch --create main
-```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# dotfiles
+
+Personal dotfiles for Fish shell, Neovim, and assorted CLI tools.
+
+The repo lives directly at `$HOME`. The root `.gitignore` ignores everything (`/*`) and
+whitelists only tracked paths, turning the home directory into a sparse git repo.
+
+## Quick setup
+
+Run from your home directory:
+
+```sh
+cd ~
+git init
+git remote add origin https://github.com/ipwnponies/dotfiles.git
+git fetch origin
+git switch --create main origin/main
+```
+
+## Structure
+
+| Path | Purpose |
+|------|---------|
+| `bin/` | Host-agnostic CLI helpers (`git-deploy`, `git-clean-remote`, `pomodoro`, …) |
+| `.config/fish/` | Fish shell configuration |
+| `.config/nvim/` | Neovim configuration (Lua, lazy.nvim) |
+| `.config/devbox/` | Devbox package manifest for dev tools |
+| `.config/aqua/` | Aqua package manager manifest |
+| `.config/npm/` | npm global package manifest |
+| `.config/venv-update/` | Poetry project for Python CLI tools |
+
+## Fish shell
+
+`conf.d/` files load in alphanumeric order. Numeric prefixes control priority:
+
+- `05-*` — XDG paths, SSH agent, base environment
+- `10-*` — Devbox integration
+- `15-*` — AI tooling (opencode)
+- `20-*` — Language toolchains (cargo, go, npm, Python/pyenv)
+- Unprefixed — Individual tool integrations (zoxide, fzf, direnv, …)
+- `z-wait.fish` — Runs last; waits for background jobs started above
+
+Each file follows a `main` / `install` pattern:
+- `install` runs on **login** shells to sync packages in the background
+- `main` runs on **interactive** shells to configure the environment
+
+## Adding packages
+
+| Ecosystem | File |
+|-----------|------|
+| CLI tools | `.config/devbox/devbox.json` — run `devbox global install` |
+| Python tools | `.config/venv-update/pyproject.toml` — runs via `poetry sync` on login |
+| Node tools | `.config/npm/package.json` — runs via `npm ci` on login |
+| Aqua tools | `.config/aqua/aqua.yaml` |


### PR DESCRIPTION
- Extract duplicated is_expired logic from 10-devbox.fish, omf.fish,
  and bd.fish into a shared functions/is_expired.fish that handles both
  Linux (stat -c %Y) and macOS (stat -f %m) transparently
- Replace hardcoded /Users/jnguyen/.pyenv/ paths in 20-virtualenv.fish
  with (pyenv root) so the config is portable across machines
- Rewrite git-deploy: add set -euo pipefail, replace eval with direct
  git push, use arrays for optional flags, fix unquoted variable tests,
  collapse redundant remote assignment, replace deprecated egrep
- Remove --allow-missing-credentials from detect-aws-credentials hook
  and bump pre-commit-hooks to v5.0.0, reorder-python-imports to
  v3.15.0, add-trailing-comma to v3.1.0
- Fix AGENTS.md: correct devbox path, expand shellcheck coverage,
  add fish syntax check and pre-commit run commands
- Fix npm.fish error message escaping; propagate zoxide exit status

https://claude.ai/code/session_01RcLBsnXZAFHxwaFbKWXy1q