### PR TITLE
Add catch-me-up skill for conversation status summaries

### DIFF
--- a/.agents/skills/catch-me-up/SKILL.md
+++ b/.agents/skills/catch-me-up/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: catch-me-up
+description: >
+  Produce a structured status summary of the current conversation.
+  Use when the user says "catch me up", "where are we", "where are we at",
+  "what's the status", "summarize for me", or "what happened".
+---
+
+Produce this exact markdown block. No prose outside it. No preamble. No commentary.
+
+---
+**Status:** [Waiting on you | In progress | Blocked on X | Complete]
+**Last action:** [One line — most recent thing decided or done. If waiting on user, make that explicit.]
+
+**Track:** [The main thread of the current conversation — what we are primarily working on or discussing]
+**Drift:** [Only include if currently in a rabbit hole relative to Track. One line describing the tangent. Omit entirely if squarely on Track.]
+
+**Open for you:**
+- [Decision or response needed from user]
+- [Omit this section entirely if nothing is pending]
+
+**Context:**
+- [Key decision or finding — max 5 bullets]
+- [Prioritise decisions over discussion]
+- [Most recent or highest impact first]
+---
+
+Rules:
+- Status and Last action always appear first
+- Track is always present
+- Drift only appears when there is a meaningful detour from Track — omit otherwise
+- Never exceed 5 context bullets
+- Never use prose paragraphs anywhere in the output
+- Never add preamble, commentary, or explanation outside the format block
+- Output must be scannable in under 30 seconds on mobile
+- This skill works identically in Claude Code agent sessions and Claude chat conversations

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 !/.config/
 !/.opencode/
 !/opencode.jsonc
+!/.agents/


### PR DESCRIPTION
## Summary
Adds a new agent skill that produces structured status summaries of the current conversation, triggered by user phrases like "catch me up", "where are we", or "what's the status".

## Changes
- **New skill definition** (`.agents/skills/catch-me-up/SKILL.md`): Defines the catch-me-up skill with a strict markdown format for status summaries including current status, last action, conversation track, any tangential drift, pending decisions, and key context bullets
- **Updated .gitignore**: Includes `.agents/` directory to track skill definitions

## Implementation Details
The skill enforces a scannable, mobile-friendly format with:
- Mandatory Status and Last action fields
- Always-present Track field for main conversation thread
- Optional Drift field (only when off-topic)
- Optional Open for you section (only when user input needed)
- Context bullets limited to 5 items, prioritizing decisions over discussion
- No prose, preamble, or commentary outside the structured format
- Works identically in Claude Code agent sessions and regular chat conversations

https://claude.ai/code/session_01WWZM1WCXXvyhbpxCJHvvCY