### PR TITLE
feat(agent): Publish skills and plugins bundle via GitHub Actions release

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,46 @@
+# Bundle Skills
+
+Zips `.agents/skills/` together with a set of vendored Claude Code plugins and
+publishes the result to the permanent `skills-latest` GitHub release, so a
+fresh cloud environment can fetch one file instead of cloning this repo or
+running `claude plugin install` itself.
+
+Runs on every push to `master` that touches `.agents/skills/**` or this
+workflow, and can be triggered manually via `workflow_dispatch`.
+
+Plugins are vendored by running the real `claude` CLI in the runner
+(`claude plugin marketplace add` + `claude plugin install`), then copying
+whatever lands in `~/.claude/plugins/cache/...` into `.agents/skills/<name>/`.
+That folder still has its `.claude-plugin/plugin.json` manifest, so once it's
+unzipped into `~/.claude/skills/` on the target machine, Claude Code
+auto-loads it as a full plugin (skills, hooks, MCP servers, etc.) with no
+install or registration step needed — see "Skills-directory plugins" in the
+[Claude Code plugins reference](https://code.claude.com/docs/en/plugins-reference).
+
+To add another plugin, add a line to `PLUGINS` (and to `MARKETPLACES` if it's
+not already on `claude-plugins-official`) in the `Install plugins` step.
+
+## Cloud environment setup script
+
+Paste this into a cloud environment's setup script to install everything this
+workflow publishes:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+curl -sfL "https://github.com/ipwnponies/dotfiles/releases/download/skills-latest/skills.zip" \
+  -o /tmp/skills.zip
+
+mkdir -p ~/.claude/skills/
+unzip -o /tmp/skills.zip -d ~/.claude/skills/
+rm /tmp/skills.zip
+
+echo "Skills installed: $(ls ~/.claude/skills/)"
+```
+
+That's it — no `claude plugin install`, no marketplace registration, no
+`GITHUB_TOKEN`. Every plugin currently bundled (`superpowers`, `context7`,
+`compound-engineering`, `caveman`) and every plain skill lands in
+`~/.claude/skills/` ready to use on the next `claude` session in that
+environment.

--- a/.github/workflows/bundle-skills.yml
+++ b/.github/workflows/bundle-skills.yml
@@ -1,0 +1,62 @@
+name: Bundle Skills
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '.agents/skills/**'
+      - '.github/workflows/bundle-skills.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: bundle-skills
+  cancel-in-progress: false
+
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install plugins
+        env:
+          MARKETPLACES: |
+            anthropics/claude-plugins-official
+          PLUGINS: |
+            superpowers@claude-plugins-official
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash
+          export PATH="$HOME/.local/bin:$PATH"
+
+          while IFS= read -r marketplace; do
+            [ -z "$marketplace" ] && continue
+            claude plugin marketplace add "$marketplace"
+          done <<< "$MARKETPLACES"
+
+          while IFS= read -r plugin; do
+            [ -z "$plugin" ] && continue
+            claude plugin install "$plugin" --scope user
+            name="${plugin%%@*}"
+            install_path=$(claude plugin list --json | jq -r --arg p "$plugin" '.[] | select(.id == $p) | .installPath')
+            rm -rf ".agents/skills/$name"
+            cp -r "$install_path" ".agents/skills/$name"
+            rm -rf ".agents/skills/$name/.git"
+          done <<< "$PLUGINS"
+
+      - name: Zip skills
+        run: cd .agents/skills && zip -r /tmp/skills.zip .
+
+      - name: Update skills-latest release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view skills-latest >/dev/null 2>&1; then
+            gh release upload skills-latest /tmp/skills.zip --clobber
+          else
+            gh release create skills-latest /tmp/skills.zip \
+              --title "Skills Bundle" \
+              --notes "Auto-generated" \
+              --prerelease
+          fi

--- a/.github/workflows/bundle-skills.yml
+++ b/.github/workflows/bundle-skills.yml
@@ -24,8 +24,13 @@ jobs:
         env:
           MARKETPLACES: |
             anthropics/claude-plugins-official
+            https://github.com/EveryInc/every-marketplace.git
+            JuliusBrussee/caveman
           PLUGINS: |
             superpowers@claude-plugins-official
+            context7@claude-plugins-official
+            compound-engineering@compound-engineering-plugin
+            caveman@caveman
         run: |
           curl -fsSL https://claude.ai/install.sh | bash
           export PATH="$HOME/.local/bin:$PATH"
@@ -42,7 +47,7 @@ jobs:
             install_path=$(claude plugin list --json | jq -r --arg p "$plugin" '.[] | select(.id == $p) | .installPath')
             rm -rf ".agents/skills/$name"
             cp -r "$install_path" ".agents/skills/$name"
-            rm -rf ".agents/skills/$name/.git"
+            rm -rf ".agents/skills/$name/.git" ".agents/skills/$name/node_modules"
           done <<< "$PLUGINS"
 
       - name: Zip skills

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 !/.opencode/
 !/opencode.jsonc
 !/.agents/
+!/.github/


### PR DESCRIPTION
## What

Adds `.github/workflows/bundle-skills.yml`, which publishes `.agents/skills/` plus a set of vendored Claude Code plugins (`superpowers`, `context7`, `compound-engineering`, `caveman`) to a permanent `skills-latest` GitHub release. See `.github/workflows/README.md` for how it works and the cloud-environment setup script.

## Why

Cloud environments need a single file to fetch instead of cloning this repo or running `claude plugin install` themselves.

## Test plan

- [x] Verified plugin install requires no auth (isolated `$HOME`, no `ANTHROPIC_API_KEY`)
- [x] Ran the workflow on GitHub Actions (temporary branch-trigger test, since reverted) — published `skills-latest` with the correct asset
- [x] Downloaded the published `skills.zip` and confirmed correct structure, zero `node_modules`
- [x] Confirmed in a fresh cloud environment that skills and plugins are live in a new session with no extra install step
