### PR TITLE
fix(agent): verify commit identity before no-op upstream rebase

### DIFF
--- a/.agents/skills/git-tidy-branch/ref/rebase-upstream.md
+++ b/.agents/skills/git-tidy-branch/ref/rebase-upstream.md
@@ -17,7 +17,9 @@ git fetch "$REMOTE"
 git rev-list HEAD.."$REMOTE/$BASE" --count
 ```
 
-If the count is 0, the branch is current — skip this step.
+If the count is 0, the branch's content is already current relative to base — skip the tree
+rebase itself. Still run the identity check below: commits this run never touched (branch
+taken over from elsewhere) may predate this session and carry a different committer.
 
 If the count is >0, back up first, then rebase:
 
@@ -43,3 +45,35 @@ If conflicts arise, read `ref/conflict-resolution.md`. To bail out at any point:
 ```bash
 git rebase --abort               # restores to REBASE_BACKUP
 ```
+
+## Verify commit identity (Claude Code Remote)
+
+Run regardless of whether the count above was 0 or the tree rebase ran. Claude Code Remote
+environments run a Stop hook that blocks every turn on any commit with a missing signature or
+a committer email that doesn't match the environment's configured identity. Rebase only
+restamps commits it actually replays — a no-op (count 0) or a rebase that fast-forwards
+without replaying leaves existing commits, and their original committer, untouched.
+
+Skip entirely when not in a Claude Code Remote environment (`commit.gpgsign` unset or false,
+no stop hook present) — nothing to normalize against.
+
+```bash
+EXPECTED_EMAIL=$(git config user.email)
+git log --format='%h %G? %ce %s' "$REMOTE/$BASE..HEAD"
+```
+
+Split findings into two cases against `$EXPECTED_EMAIL` — they need different handling:
+
+- **Committer already matches `$EXPECTED_EMAIL`, only `%G?`==`N`.** This environment has no
+  `gpg.ssh.allowedSignersFile` configured, so even a commit Claude genuinely signed this
+  session reports `N` locally (not a real signal). Re-sign silently, no user input needed:
+  ```bash
+  git rebase --exec "git commit --amend --no-edit --reset-author" "$REMOTE/$BASE"
+  ```
+
+- **Committer does NOT match `$EXPECTED_EMAIL`.** Real signal — commit(s) Claude didn't create
+  this session. **Stop and ask the user before rewriting anything.** Show the flagged commits
+  (`%h %ce %s`) and confirm it's OK to reclaim them under the current identity (rewrite
+  committer, re-sign, changes their SHA) before running the same `reset-author` rebase. If
+  declined, leave as-is and note the Stop hook will keep blocking on push until resolved
+  manually.


### PR DESCRIPTION
The rebase-onto-base reference skipped entirely when the base hadn't moved, so a branch taken over from elsewhere (prior session, human's own checkout, GitHub-UI commit) could keep a foreign committer that the Claude Code Remote Stop hook then blocks on every turn.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nur1TGud5Waz2YRy7XKVeJ)_