### PR TITLE
fix(agent): truncate multiline commit message in progress comment

### DIFF
--- a/.agents/skills/git-tidy-branch/scripts/extract_hunks.py
+++ b/.agents/skills/git-tidy-branch/scripts/extract_hunks.py
@@ -226,7 +226,8 @@ def main():
 
     for idx, commit in enumerate(commits):
         msg = commit['message']
-        script_lines.append(f'# ── Commit {idx + 1}: {msg} ──')
+        subject = msg.splitlines()[0] if msg else msg
+        script_lines.append(f'# ── Commit {idx + 1}: {subject} ──')
 
         for file_spec in commit['hunks']:
             filepath = file_spec['file']


### PR DESCRIPTION
A commit-plan.json message with a body (subject + blank line + body) leaked its body lines verbatim into a single '#'-prefixed comment in the generated staging script, so the body lines ran as literal shell commands instead of being commented out.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nur1TGud5Waz2YRy7XKVeJ)_